### PR TITLE
Added cloudwatchevent.json from real event

### DIFF
--- a/cloudwatchevent.json
+++ b/cloudwatchevent.json
@@ -1,0 +1,16 @@
+{
+    "version": "0",
+    "id": "9c595e18-ee46-72bf-d6ec-98801c66d384",
+    "detail-type": "EC2 Instance State-change Notification",
+    "source": "aws.ec2",
+    "account": "805746249177",
+    "time": "2020-07-24T14: 16: 00Z",
+    "region": "ap-south-1",
+    "resources": [
+        "arn:aws:ec2:ap-south-1: 805746249177:instance/i-0ed156af7d3b33dc6"
+    ],
+    "detail": {
+        "instance-id": "i-0ed156af7d3b33dc6",
+        "state": "stopped"
+    }
+}


### PR DESCRIPTION
This is the JSON that is passed into event by CloudWatch to Lambda.
From this we can get the state and the instance id.
Do merge this file into your code.

Also, give your repo a descriptive name 
for ex: route53-dns-assign-to-IPv4